### PR TITLE
Fix voltage and CT channel activation bitmask bug

### DIFF
--- a/src/emon_CM.c
+++ b/src/emon_CM.c
@@ -216,7 +216,7 @@ void ecmConfigChannel(int_fast8_t ch) {
 
 void configChannelCT(int_fast8_t ch) {
   channelActive[ch + NUM_V] = ecmCfg.ctCfg[ch].active;
-  datasetProc.activeCh      = ecmCfg.ctCfg[ch].active << (ch + NUM_V);
+  datasetProc.activeCh |= ecmCfg.ctCfg[ch].active << (ch + NUM_V);
   ecmCfg.ctCfg[ch].ctCal =
       calibrationAmplitude(ecmCfg.ctCfg[ch].ctCalRaw, false);
 
@@ -227,8 +227,8 @@ void configChannelCT(int_fast8_t ch) {
 }
 
 void configChannelV(int_fast8_t ch) {
-  channelActive[ch]    = ecmCfg.vCfg[ch].vActive;
-  datasetProc.activeCh = ecmCfg.vCfg[ch].vActive << ch;
+  channelActive[ch] = ecmCfg.vCfg[ch].vActive;
+  datasetProc.activeCh |= ecmCfg.vCfg[ch].vActive << ch;
   ecmCfg.vCfg[ch].voltageCal =
       calibrationAmplitude(ecmCfg.vCfg[ch].voltageCalRaw, true);
 }


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where only the last configured voltage or CT channel would be active on boot, even though the configuration correctly showed all channels as active.

## Problem
When multiple voltage channels (V2, V3) or CT channels were configured as active:
- The configuration (`l` command) showed all channels as active ✅
- But the actual energy monitoring output only included the **last** configured channel ❌
- Manually re-activating a channel via the `k` command would make it appear, but this shouldn't be necessary

Example scenario:
1. Configure V1, V2, V3 as active using `k2 1 100.0` and `k3 1 100.0`
2. Save with `s` and reboot
3. Run `l` - shows V1, V2, V3 all active ✅
4. Check serial output - only shows V1 ❌
5. Send `k2 1 100.0` again - now V2 appears too

## Root Cause
In `configChannelV()` and `configChannelCT()`, the code was using **assignment (`=`)** instead of **bitwise OR (`|=`)** when setting bits in the `datasetProc.activeCh` bitmask:

```c
// WRONG - overwrites entire bitmask, losing previously set bits
datasetProc.activeCh = ecmCfg.vCfg[ch].vActive << ch;

// CORRECT - sets the bit while preserving others
datasetProc.activeCh |= ecmCfg.vCfg[ch].vActive << ch;
```

### What Was Happening
During `ecmConfigInit()` at startup, it loops through all voltage channels:
1. **V1 (ch=0)**: Sets bit 0 → `activeCh = 0b00000001`
2. **V2 (ch=1)**: **Overwrites** with bit 1 → `activeCh = 0b00000010` (lost V1!)
3. **V3 (ch=2)**: **Overwrites** with bit 2 → `activeCh = 0b00000100` (lost V1 and V2!)

Result: Only V3 was marked active in the output dataset.

The same issue affected CT channels.

## Solution
Changed assignment (`=`) to bitwise OR (`|=`) in:
- `configChannelV()` ([src/emon_CM.c:231](https://github.com/FredM67/emon32-fw/blob/fix-voltage-channel-bitmask/src/emon_CM.c#L231))
- `configChannelCT()` ([src/emon_CM.c:219](https://github.com/FredM67/emon32-fw/blob/fix-voltage-channel-bitmask/src/emon_CM.c#L219))

Now each channel correctly sets its bit without clearing the others.

## Testing
- ✅ Configured V1, V2, V3 as active
- ✅ Saved configuration and rebooted
- ✅ Verified all three voltage channels appear in serial output immediately on boot
- ✅ No need to manually re-activate channels
- ✅ Build successful: 46372 bytes (32 bytes reduction)

## Impact
- **Fixes 3-phase voltage monitoring** - V1, V2, V3 now all work on boot
- **Fixes multi-CT configurations** - All configured CTs now work on boot
- **Critical for proper 3-phase power monitoring**
- No breaking changes to existing functionality

## Related
This bug would affect any user trying to monitor 3-phase power or use multiple voltage/CT channels simultaneously.