### PR TITLE
[NVM] Store on pulse count increment

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -113,7 +113,7 @@ static void configDefault(void) {
   config.baseCfg.reportCycles =
       configTimeToCycles(REPORT_TIME_DEF, MAINS_FREQ_DEF);
   config.baseCfg.assumedVrms  = ASSUMED_VRMS_DEF;
-  config.baseCfg.whDeltaStore = DELTA_WH_STORE_DEF;
+  config.baseCfg.epDeltaStore = DELTA_EP_STORE_DEF;
   config.baseCfg.dataGrp      = GROUP_ID_DEF;
   config.baseCfg.logToSerial  = true;
   config.baseCfg.useJson      = false;

--- a/src/configuration.h
+++ b/src/configuration.h
@@ -12,7 +12,7 @@ typedef struct __attribute__((__packed__)) BaseCfg_ {
   uint8_t  nodeID;       /* ID for report*/
   uint8_t  mainsFreq;    /* Mains frequency */
   uint16_t reportCycles; /* Cycles between reports */
-  uint16_t whDeltaStore; /* Minimum energy delta to store */
+  uint16_t epDeltaStore; /* Minimum energy/pulse delta to store */
   uint8_t  dataGrp;      /* Transmission group - default 210 */
   bool     logToSerial;  /* Log data to serial output */
   bool     useJson;      /* JSON format for serial output */

--- a/src/emon32.h
+++ b/src/emon32.h
@@ -13,7 +13,7 @@ _Static_assert((sizeof(bool) == 1), "bool must be 1 byte");
 
 #define DOWNSAMPLE_DSP     1u   /* 0: no downsampling; 1: half band LPF */
 #define NUM_CT_ACTIVE_DEF  6    /* Onboard CTs only */
-#define DELTA_WH_STORE_DEF 200u /* Threshold, in Wh, to store to NVM */
+#define DELTA_EP_STORE_DEF 200u /* Threshold, in Wh/count, to store to NVM */
 #define NODE_ID_DEF        17u  /* Node ID for reports */
 #define GROUP_ID_DEF       210u /* Group ID default for OEM */
 #define MAINS_FREQ_DEF     50u  /* Mains frequency */


### PR DESCRIPTION
  - Store energy and pulse when pulse count change is > storage delta. Treats 1 pulse == 1 Wh, not true in general case but rasonable criterion for storage.