### PR TITLE
Fix CRC error after zeroing accumulators

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1111,8 +1111,7 @@ static void handleConfirmation(char c) {
 
   case CONFIRM_ZERO_ACCUM:
     if ('y' == c) {
-      eepromInitBlock(EEPROM_WL_OFFSET, 0, (1024 - EEPROM_WL_OFFSET));
-      serialPuts("    - Accumulators cleared.\r\n");
+      serialPuts("    - Clearing accumulators...\r\n");
       emon32EventSet(EVT_CLEAR_ACCUM);
     } else {
       serialPuts("    - Cancelled.\r\n");

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -434,19 +434,16 @@ eepromWLStatus_t eepromReadWL(void *pPktRd, int32_t *pIdx) {
 }
 
 void eepromWLClear(void) {
-  WLHeader_t wlHeader;
-
+  /* Zero the entire WL area */
   eepromInitBlock(EEPROM_WL_OFFSET, 0, (EEPROM_SIZE - EEPROM_WL_OFFSET));
 
-  memset(wlData, 0, WL_PKT_SIZE);
-  wlHeader.valid       = 0;
-  wlHeader.res0        = 0;
-  wlHeader.crc16_ccitt = calcCRC16_ccitt(wlData, wlData_n);
+  /* Reset state to force re-initialization on next access */
+  wlIdxNxtWr     = 0;
+  wlCurrentValid = 1;
 
-  for (int32_t i = 0; i < wlBlkCnt; i++) {
-    int32_t addr = EEPROM_WL_OFFSET + (i * wlBlkSize);
-    eepromWrite(addr, &wlHeader, sizeof(wlHeader));
-  }
+  /* Write one valid record with zeroed data using existing write logic */
+  memset(wlData, 0, WL_PKT_SIZE);
+  eepromWriteWL(wlData, 0);
 }
 
 void eepromWLReset(int32_t len) {

--- a/src/emon32.c
+++ b/src/emon32.c
@@ -710,6 +710,7 @@ int main(void) {
         for (int32_t i = 0; i < NUM_OPA; i++) {
           pulseSetCount(i, 0);
         }
+        serialPuts("    - Accumulators cleared.\r\n");
         emon32EventClr(EVT_CLEAR_ACCUM);
       }
 


### PR DESCRIPTION
## Summary

- Fix `eepromWLClear()` which was not waiting for each header write to complete, causing CRC validation failures when reading back cleared accumulators
- Simplify by reusing existing `eepromWriteWL()` logic instead of duplicating write handling
- Remove redundant `eepromInitBlock()` call from configuration.c

## Problem

After using 'z' + 'y' to zero accumulators, calling 'lh' would show:
```
EEPROM CRC retry: hdr=0x0000 data=0x99AF
EEPROM CRC FAIL: hdr=0x0000 data=0x99AF valid=0x00
```

The old `eepromWLClear()` loop called `eepromWrite()` for each block without waiting, so only block 0 got a valid header. Reads from other blocks found zeroed headers (CRC=0x0000) that didn't match the calculated CRC of zeroed data (0x99AF).

## Test plan

- [ ] Flash firmware
- [ ] Run 'z' then 'y' to zero accumulators
- [ ] Run 'lh' to list accumulators - should show zeroed values without CRC error

🤖 Generated with [Claude Code](https://claude.ai/code)