### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ You will also need to ensure that the vendor's headers are included and visible 
 - [SSD1306 library](https://github.com/Matiasus/SSD1306/tree/master) - used as a reference for this implementation.
 - [tinyUSB](https://github.com/hathach/tinyusb) - USB library (derived from [_236aa9622_](https://github.com/hathach/tinyusb/commit/236aa9622a31b8c4727c98c6d683cee011fb8f9b)).
 - [Using Asserts in Embedded Systems](https://interrupt.memfault.com/blog/asserts-in-embedded-systems) - custom assertions from _Interrupt by Memfault_.
-- [Wintertools](https://github.com/https://github.com/wntrblm/wintertools) - various build and linker scripts from Winterbloom.
+- [Wintertools](https://github.com/wntrblm/wintertools) - various build and linker scripts from Winterbloom.
 
 ### Others
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -4,7 +4,7 @@
 
 ## Schematic
 
-![emonPi3 / emonTx6 v1.0 schematic](img/schematic.png)
+![emonPi3 / emonTx6 v1.0 schematic](img/emonpi3_schematic.png)
 
 ## Voltage sensor pinout
 


### PR DESCRIPTION
## Summary
- Fix Wintertools URL in README.md (duplicate `https://github.com/` prefix)
- Fix schematic image path in docs/hardware.md (`schematic.png` → `emonpi3_schematic.png`)

## Test plan
- [x] Verify Wintertools link works: https://github.com/wntrblm/wintertools
- [x] Verify schematic image exists at `docs/img/emonpi3_schematic.png`

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)