### PR TITLE
Fix JSON output showing inactive pulse channels

### DIFF
--- a/src/emon32.c
+++ b/src/emon32.c
@@ -544,7 +544,8 @@ static void transmitData(const Emon32Dataset_t *pSrc, const TransmitOpt_t *pOpt,
 
   for (size_t i = 0; i < NUM_OPA; i++) {
     uint8_t func       = pConfig->opaCfg[i].func;
-    chsActive.pulse[i] = ('r' == func) || ('f' == func) || ('b' == func);
+    bool    isPulse    = ('r' == func) || ('f' == func) || ('b' == func);
+    chsActive.pulse[i] = pConfig->opaCfg[i].opaActive && isPulse;
   }
 
   (void)dataPackSerial(pSrc, txBuffer, TX_BUFFER_W, pOpt->json, chsActive);


### PR DESCRIPTION
## Summary
- Check `opaActive` in addition to function type when determining if a pulse channel should appear in JSON output
- Makes pulse behavior consistent with CT channels, where inactive channels are hidden from JSON output

## Problem
When JSON output is enabled, inactive pulse counters still appeared in the output even when the OPA channel is disabled (`opaActive = 0`).

Example with all OPA channels inactive:
```
opa1 = active 0, pulse
```
JSON output incorrectly showed: `"pulse1":0`

## Solution
Changed the condition in `transmitData()` from:
```c
chsActive.pulse[i] = ('r' == func) || ('f' == func) || ('b' == func);
```
To:
```c
bool isPulse = ('r' == func) || ('f' == func) || ('b' == func);
chsActive.pulse[i] = pConfig->opaCfg[i].opaActive && isPulse;
```

## Test plan
- [ ] Configure an OPA channel as pulse but set it inactive
- [ ] Verify pulse data no longer appears in JSON output
- [ ] Configure an OPA channel as pulse and set it active
- [ ] Verify pulse data appears in JSON output

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)