### PR TITLE
Show pulse edge type in OPA config output

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -936,9 +936,13 @@ static void printSettingOPA(const int32_t ch) {
     return;
   }
 
-  /* Pulse */
-  printf_("active = %s, pulse, pullUp = %s, pulsePeriod = %d\r\n",
-          (config.opaCfg[ch].opaActive ? "1" : "0"),
+  /* Pulse - show edge type */
+  const char *edgeStr = ('r' == config.opaCfg[ch].func)   ? "rising"
+                        : ('f' == config.opaCfg[ch].func) ? "falling"
+                                                          : "both";
+
+  printf_("active = %s, pulse = %s, pullUp = %s, pulsePeriod = %d\r\n",
+          (config.opaCfg[ch].opaActive ? "1" : "0"), edgeStr,
           config.opaCfg[ch].puEn ? "on" : "off", config.opaCfg[ch].period);
 }
 


### PR DESCRIPTION
## Summary
Display the configured edge type (rising/falling/both) in the OPA settings output.

## Changes
- Modified `printSettingOPA()` to show the edge type for pulse inputs

## Before
```
opa1 active = 1, pulse, pullUp = off, pulsePeriod = 100
```

## After
```
opa1 active = 1, pulse = falling, pullUp = off, pulsePeriod = 100
```

## Test plan
- [ ] Configure OPA with `m1 1 r 0 100` and verify output shows "pulse = rising"
- [ ] Configure OPA with `m1 1 f 0 100` and verify output shows "pulse = falling"
- [ ] Configure OPA with `m1 1 b 0 100` and verify output shows "pulse = both"
- [ ] Run `l` command and verify OPA settings show edge type

Fixes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)