### PR TITLE
Fix: Attach build artifacts to GitHub Release

### DIFF
--- a/.github/workflows/build-arm.yml
+++ b/.github/workflows/build-arm.yml
@@ -31,3 +31,8 @@ jobs:
               with:
                 name: firmware-${{ github.ref_name }}
                 path: bin/emon32*.*
+
+            - name: Upload to Release
+              uses: softprops/action-gh-release@v2
+              with:
+                files: bin/emon32*.*


### PR DESCRIPTION
## Summary

Add `softprops/action-gh-release` step to upload firmware files to the GitHub Release page.

Previously, the workflow only used `actions/upload-artifact` which uploads to the workflow run, not to the release itself. This meant users couldn't download firmware from release pages like https://github.com/openenergymonitor/emon32-fw/releases/tag/V0.99.0

## Changes

- Add release upload step using `softprops/action-gh-release@v2`
- Keeps existing artifact upload for workflow run history

## Test plan

- [ ] Create a new tag/release and verify artifacts appear on the release page

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)