### PR TITLE
[Config] Add 'q' command to reload saved configuration

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -1528,6 +1528,7 @@ void configProcessCmd(void) {
       "   - x = s   : save current addresses\r\n"
       "   - x = <n> : save address to index n\r\n"
       " - p<n>        : set the RF power level\r\n"
+      " - q           : reload saved config (undo unsaved changes)\r\n"
       " - r           : restore defaults\r\n"
       " - s           : save settings to NVM\r\n"
       " - t           : trigger report on next cycle\r\n"
@@ -1643,6 +1644,13 @@ void configProcessCmd(void) {
       unsavedChange = true;
       emon32EventSet(EVT_CONFIG_CHANGED);
     }
+    break;
+  case 'q':
+    /* Reload saved configuration from NVM (undo unsaved changes) */
+    eepromRead(0, &config, sizeof(config));
+    serialPuts("> Reloaded saved configuration.\r\n");
+    unsavedChange = false;
+    emon32EventSet(EVT_CONFIG_CHANGED);
     break;
   case 'r':
     configDefault();


### PR DESCRIPTION
## Summary
- Add serial command `q` to reload the last saved configuration from EEPROM
- Discards any unsaved changes without resetting to factory defaults
- Complements existing `r` (restore defaults) and `s` (save) commands

## Test plan
- [ ] Make configuration changes (e.g., change node ID with `n<id>`)
- [ ] Verify `unsavedChange` is set (visible in status)
- [ ] Send `q` command
- [ ] Verify configuration reverts to previously saved values
- [ ] Verify `unsavedChange` is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)