### PR TITLE
[Fix] Eliminate I2C recovery events on EEPROM operations

### DIFF
--- a/src/driver_SERCOM.c
+++ b/src/driver_SERCOM.c
@@ -340,7 +340,8 @@ I2CM_Status_t i2cActivate(Sercom *sercom, const uint32_t addr) {
   /* MB: master on bus, SB: slave on bus */
   while (!(sercom->I2CM.INTFLAG.reg &
            (SERCOM_I2CM_INTFLAG_MB | SERCOM_I2CM_INTFLAG_SB))) {
-    if (timerMicrosDelta(t) > I2CM_ACTIVATE_TIMEOUT_US) {
+    uint32_t delta = timerMicrosDelta(t);
+    if (delta > I2CM_ACTIVATE_TIMEOUT_US) {
       return I2CM_TIMEOUT;
     }
   }
@@ -364,6 +365,29 @@ void i2cAck(Sercom *sercom, const I2CM_Ack_t ack, const I2CM_AckCmd_t cmd) {
       (ack << SERCOM_I2CM_CTRLB_ACKACT_Pos) | SERCOM_I2CM_CTRLB_CMD(cmd);
   while (sercom->I2CM.SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_SYSOP)
     ;
+
+  /* After STOP, verify bus returns to IDLE. SYNCBUSY only confirms the
+   * command register write was synced, not that the physical STOP completed.
+   * If the bus doesn't reach IDLE within 100us, the SERCOM state machine is
+   * stuck. Do NOT re-issue STOP — issuing a CMD while the bus is mid-
+   * transition can violate the I2C protocol and permanently hang the SERCOM.
+   * Instead, perform a software reset and reinitialize. Per the datasheet,
+   * SWRST is the only reliable recovery from a hung state, and BUSSTATE can
+   * be forced to IDLE from the resulting UNKNOWN state.
+   */
+  if (I2CM_ACK_CMD_STOP == cmd) {
+    uint32_t t = timerMicros();
+    while ((sercom->I2CM.STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) !=
+           SERCOM_I2CM_STATUS_BUSSTATE(1u)) {
+      if (timerMicrosDelta(t) > 100u) {
+        sercom->I2CM.CTRLA.reg = SERCOM_I2CM_CTRLA_SWRST;
+        while (sercom->I2CM.CTRLA.reg & SERCOM_I2CM_CTRLA_SWRST)
+          ;
+        i2cmCommon(sercom);
+        break;
+      }
+    }
+  }
 }
 
 I2CM_Status_t i2cDataWrite(Sercom *sercom, const uint8_t data) {

--- a/src/driver_TIME.c
+++ b/src/driver_TIME.c
@@ -9,6 +9,7 @@
  */
 static void commonSetup(const uint32_t delay);
 static void timerSync(Tc *tc);
+static void timerTickRestoreRCONT(void);
 
 static volatile uint32_t timeMillisCounter  = 0;
 static volatile uint32_t timeSecondsCounter = 0;
@@ -48,6 +49,18 @@ static void timerSync(Tc *tc) {
   /* All STATUS registers are at the same offset, use COUNT32 for access */
   while (tc->COUNT32.STATUS.reg & TC_STATUS_SYNCBUSY)
     ;
+}
+
+/*! @brief Restore RCONT on TIMER_TICK after a core register write clears it.
+ *  Writing to any core register (COUNT, CC[0], CC[1]) clears RCONT.
+ *  RREQ must be set once after RCONT to start continuous mode (datasheet
+ *  30.8.6). Must poll SYNCBUSY first to avoid CPU stall.
+ */
+static void timerTickRestoreRCONT(void) {
+  timerSync(TIMER_TICK);
+  TIMER_TICK->COUNT32.READREQ.reg =
+      TC_READREQ_RCONT | TC_READREQ_RREQ | TC_READREQ_ADDR(0x10);
+  timerSync(TIMER_TICK);
 }
 
 uint16_t timerADCPeriod(void) {
@@ -111,9 +124,14 @@ uint32_t timerElapsedStop(void) {
 }
 
 uint32_t timerMicros(void) {
-  /* Resynchronise COUNT32.COUNT, and then return the result */
-  TIMER_TICK->COUNT32.READREQ.reg = TC_READREQ_RREQ | TC_READREQ_ADDR(0x10);
-  timerSync(TIMER_TICK);
+  /* RCONT (Read Continuously) keeps COUNT synchronized from the timer clock
+   * domain to the APB bus on every CLK_TCx edge (1 MHz). A single 32-bit
+   * register read is atomic on Cortex-M0+, so no interrupt protection needed.
+   *
+   * IMPORTANT: RCONT is cleared by any write to a TC core register (COUNT,
+   * CC[0], CC[1]). All such writes MUST call timerTickRestoreRCONT() after,
+   * or this function will return stale values.
+   */
   return TIMER_TICK->COUNT32.COUNT.reg;
 }
 
@@ -206,6 +224,21 @@ void timerSetup(void) {
   TIMER_TICK->COUNT32.CTRLA.bit.ENABLE = 1;
   timerSync(TIMER_TICK);
 
+  /* Enable continuous read synchronization for COUNT register (0x10).
+   * Without RCONT, each timerMicros() call must issue a one-shot READREQ
+   * and wait for SYNCBUSY. There is a race: SYNCBUSY propagates from the
+   * timer clock domain to the APB domain asynchronously, so polling it
+   * immediately after writing RREQ can find it still clear from the
+   * PREVIOUS sync, causing a stale COUNT read (observed as ~180 us jump).
+   * With RCONT, hardware issues a read request on every CLK_TCx edge
+   * (1 MHz), keeping the APB-side COUNT always fresh (within ~1 us).
+   *
+   * RREQ must be set once after RCONT to start continuous mode (datasheet
+   * 30.8.6). RCONT is cleared by any write to a core register (COUNT, CC),
+   * so timerTickRestoreRCONT() must be called after CC[1] writes.
+   */
+  timerTickRestoreRCONT();
+
   /* Setup SysTick for 1 ms periodic tick
    * Core clock is F_CORE, so (F_CORE / 1000) ticks = 1 ms
    */
@@ -262,7 +295,7 @@ bool timerScheduleCallback(TimerCallback_t callback, uint32_t delay_us) {
   if (need_update) {
     TIMER_TICK->COUNT32.INTENSET.reg = TC_INTENSET_MC1;
     TIMER_TICK->COUNT32.CC[1].reg    = target_us;
-    timerSync(TIMER_TICK); /* Sync outside critical section */
+    timerTickRestoreRCONT(); /* CC write clears RCONT; restore it */
   }
 
   return (slot != SIZE_MAX);
@@ -336,7 +369,7 @@ static void processCallbackQueue(uint32_t current_us) {
   if (found_next) {
     nextScheduledEvent_us         = next_event;
     TIMER_TICK->COUNT32.CC[1].reg = next_event;
-    timerSync(TIMER_TICK);
+    timerTickRestoreRCONT(); /* CC write clears RCONT; restore it */
   } else {
     /* No more pending events */
     nextScheduledEvent_us            = UINT32_MAX;

--- a/src/eeprom.c
+++ b/src/eeprom.c
@@ -80,6 +80,22 @@ static uint8_t          nextValidByte(const uint8_t currentValid);
 static eepromWLStatus_t wlFindLast(void);
 static I2CM_Status_t    writeBytes(wrLocal_t *wr, uint32_t n);
 
+/* Diagnostic: last I2C error context for "WR FAIL!" / "RD FAIL!" messages.
+ *   phase: 'A'ctivate, 'L'SB, 'D'ata (uppercase=write, lowercase=read,
+ *          'r'=read re-activate)
+ *   status: I2CM_Status_t value (1=ERROR, 2=TIMEOUT, 3=NOACK)
+ *   retries: retry count (activate phase only)
+ *   sercomStatus: SERCOM I2CM STATUS register at point of failure
+ *   preState: SERCOM I2CM STATUS register BEFORE i2cActivate() call
+ *     Bits: [4:5]=BUSSTATE (0=UNK,1=IDLE,2=OWNER,3=BUSY)
+ *           [0]=BUSERR [1]=ARBLOST [6]=LOWTOUT [7]=CLKHOLD
+ */
+static char          lastI2CErrPhase       = '?';
+static I2CM_Status_t lastI2CErrStatus      = I2CM_SUCCESS;
+static uint8_t       lastI2CErrRetries     = 0;
+static uint16_t      lastI2CErrSercomState = 0;
+static uint16_t      lastI2CErrPreState    = 0; /* STATUS before i2cActivate */
+
 /* Local values */
 static uint32_t eepromSizeBytes = EEPROM_SIZE;
 
@@ -199,31 +215,62 @@ static eepromWLStatus_t wlFindLast(void) {
  *  @return Status from the write
  */
 static I2CM_Status_t writeBytes(wrLocal_t *wr, uint32_t n) {
-  I2CM_Status_t i2cm_s;
-  Address_t     address = calcAddress(wr->addr);
+  I2CM_Status_t  i2cm_s;
+  Address_t      address  = calcAddress(wr->addr);
+  const uint32_t nToWrite = n;
 
-  /* Setup next transaction */
-  wr->addr += n;
-  wr->n_residual -= n;
-
-  /* Write to select, then lower address */
-  i2cm_s = i2cActivate(SERCOM_I2CM, address.msb);
-  if (I2CM_SUCCESS != i2cm_s) {
+  /* Retry loop: EEPROM NACKs address during internal write cycle.
+   * STOP + 500us delay per retry, up to 10 retries (~5ms total).
+   */
+  for (unsigned retry = 0;; retry++) {
+    uint16_t preStatus = SERCOM_I2CM->I2CM.STATUS.reg;
+    i2cm_s             = i2cActivate(SERCOM_I2CM, address.msb);
+    if (I2CM_SUCCESS == i2cm_s) {
+      break;
+    }
+    /* Capture SERCOM status BEFORE STOP changes it */
+    uint16_t sercomStatus = SERCOM_I2CM->I2CM.STATUS.reg;
+    /* Release bus before retry or return */
+    i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
+    if ((I2CM_NOACK == i2cm_s) && (retry < 10)) {
+      timerDelay_us(500);
+      continue;
+    }
+    /* TIMEOUT, ERROR, or NOACK retries exhausted */
+    lastI2CErrPhase       = 'A';
+    lastI2CErrStatus      = i2cm_s;
+    lastI2CErrRetries     = retry;
+    lastI2CErrSercomState = sercomStatus;
+    lastI2CErrPreState    = preStatus;
     return i2cm_s;
   }
 
   i2cm_s = i2cDataWrite(SERCOM_I2CM, (uint8_t)address.lsb);
   if (I2CM_SUCCESS != i2cm_s) {
+    lastI2CErrPhase       = 'L';
+    lastI2CErrStatus      = i2cm_s;
+    lastI2CErrRetries     = 0;
+    lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+    i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
     return i2cm_s;
   }
 
   while (n--) {
     i2cm_s = i2cDataWrite(SERCOM_I2CM, *wr->pData++);
     if (I2CM_SUCCESS != i2cm_s) {
+      lastI2CErrPhase       = 'D';
+      lastI2CErrStatus      = i2cm_s;
+      lastI2CErrRetries     = 0;
+      lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+      i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
       return i2cm_s;
     }
   }
   i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
+
+  /* Advance state only after successful transaction */
+  wr->addr += nToWrite;
+  wr->n_residual -= nToWrite;
 
   return i2cm_s;
 }
@@ -291,17 +338,20 @@ void eepromInitBlock(uint32_t startAddr, const uint32_t val, size_t n) {
     address = calcAddress(startAddr);
     i2cm_s  = i2cActivate(SERCOM_I2CM, address.msb);
     if (I2CM_SUCCESS != i2cm_s) {
+      i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
       return;
     }
 
     i2cm_s = i2cDataWrite(SERCOM_I2CM, (uint8_t)address.lsb);
     if (I2CM_SUCCESS != i2cm_s) {
+      i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
       return;
     }
 
     for (size_t i = 0; i < EEPROM_PAGE_SIZE; i++) {
       i2cm_s = i2cDataWrite(SERCOM_I2CM, (uint8_t)val);
       if (I2CM_SUCCESS != i2cm_s) {
+        i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
         return;
       }
     }
@@ -343,13 +393,26 @@ bool eepromRead(uint32_t addr, void *pDst, size_t n) {
 
   /* Write select with address high and ack with another start, then send low
    * byte of address */
-  i2cm_s = i2cActivate(SERCOM_I2CM, address.msb);
+  uint16_t preStatus = SERCOM_I2CM->I2CM.STATUS.reg;
+  i2cm_s             = i2cActivate(SERCOM_I2CM, address.msb);
   if (I2CM_SUCCESS != i2cm_s) {
+    lastI2CErrPhase       = 'a';
+    lastI2CErrStatus      = i2cm_s;
+    lastI2CErrRetries     = 0;
+    lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+    lastI2CErrPreState    = preStatus;
+    i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
     return false;
   }
 
   i2cm_s = i2cDataWrite(SERCOM_I2CM, (uint8_t)address.lsb);
   if (I2CM_SUCCESS != i2cm_s) {
+    lastI2CErrPhase       = 'l';
+    lastI2CErrStatus      = i2cm_s;
+    lastI2CErrRetries     = 0;
+    lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+    lastI2CErrPreState    = 0;
+    i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
     return false;
   }
 
@@ -357,14 +420,26 @@ bool eepromRead(uint32_t addr, void *pDst, size_t n) {
    * final byte, respond with NACK */
   address.msb += 1u;
 
-  i2cm_s = i2cActivate(SERCOM_I2CM, address.msb);
+  preStatus = SERCOM_I2CM->I2CM.STATUS.reg;
+  i2cm_s    = i2cActivate(SERCOM_I2CM, address.msb);
   if (I2CM_SUCCESS != i2cm_s) {
+    lastI2CErrPhase       = 'r';
+    lastI2CErrStatus      = i2cm_s;
+    lastI2CErrRetries     = 0;
+    lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+    lastI2CErrPreState    = preStatus;
+    i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
     return false;
   }
 
   while (n) {
     i2cm_s = i2cDataRead(SERCOM_I2CM, pData++);
     if (I2CM_SUCCESS != i2cm_s) {
+      lastI2CErrPhase       = 'd';
+      lastI2CErrStatus      = i2cm_s;
+      lastI2CErrRetries     = 0;
+      lastI2CErrSercomState = SERCOM_I2CM->I2CM.STATUS.reg;
+      i2cAck(SERCOM_I2CM, I2CM_ACK, I2CM_ACK_CMD_STOP);
       return false;
     }
     n--;
@@ -548,6 +623,9 @@ static void eepromWLAsyncCallback(void) {
                          sizeof(wlAsyncCtx.header));
     if (status == EEPROM_WR_FAIL) {
       /* I2C failed - perform bus recovery and retry once */
+      printf_("WR FAIL! %c:%d r%u s0x%04X pre0x%04X (retry)\r\n",
+              lastI2CErrPhase, lastI2CErrStatus, lastI2CErrRetries,
+              lastI2CErrSercomState, lastI2CErrPreState);
       eepromBusRecovery();
       status = eepromWrite(wlAsyncCtx.addrWr, (const void *)&wlAsyncCtx.header,
                            sizeof(wlAsyncCtx.header));
@@ -587,7 +665,9 @@ static void eepromWLAsyncCallback(void) {
         wlAsyncCtx.state = WL_ASYNC_IDLE;
       }
     } else if (status == EEPROM_WR_FAIL) {
-      printf_("WR FAIL!\r\n");
+      printf_("WR FAIL! %c:%d r%u s0x%04X pre0x%04X\r\n", lastI2CErrPhase,
+              lastI2CErrStatus, lastI2CErrRetries, lastI2CErrSercomState,
+              lastI2CErrPreState);
       eepromBusRecovery();
       wlAsyncCtx.busyRetries = 0;
       wlAsyncCtx.state       = WL_ASYNC_IDLE;
@@ -616,7 +696,9 @@ static void eepromWLAsyncCallback(void) {
         wlAsyncCtx.state = WL_ASYNC_IDLE;
       }
     } else if (status == EEPROM_WR_FAIL) {
-      printf_("WR FAIL!\r\n");
+      printf_("WR FAIL! %c:%d r%u s0x%04X pre0x%04X\r\n", lastI2CErrPhase,
+              lastI2CErrStatus, lastI2CErrRetries, lastI2CErrSercomState,
+              lastI2CErrPreState);
       eepromBusRecovery();
       wlAsyncCtx.state = WL_ASYNC_IDLE;
     }
@@ -652,7 +734,9 @@ static void eepromWLAsyncCallback(void) {
         wlAsyncCtx.state = WL_ASYNC_IDLE;
       }
     } else if (status == EEPROM_WR_FAIL) {
-      printf_("WR FAIL!\r\n");
+      printf_("WR FAIL! %c:%d r%u s0x%04X pre0x%04X\r\n", lastI2CErrPhase,
+              lastI2CErrStatus, lastI2CErrRetries, lastI2CErrSercomState,
+              lastI2CErrPreState);
       eepromBusRecovery();
       wlAsyncCtx.state = WL_ASYNC_IDLE;
     }
@@ -681,6 +765,8 @@ static void eepromWLAsyncCallback(void) {
         uint32_t validByte;
         if (!eepromRead(wlAsyncCtx.addrWr, &validByte, 1u)) {
           /* Read failed - cannot update valid byte, treat as error */
+          printf_("RD FAIL! %c:%d s0x%04X pre0x%04X\r\n", lastI2CErrPhase,
+                  lastI2CErrStatus, lastI2CErrSercomState, lastI2CErrPreState);
           wlAsyncCtx.state = WL_ASYNC_IDLE;
           break;
         }
@@ -700,7 +786,9 @@ static void eepromWLAsyncCallback(void) {
         wlAsyncCtx.state = WL_ASYNC_IDLE;
       }
     } else if (status == EEPROM_WR_FAIL) {
-      printf_("WR FAIL!\r\n");
+      printf_("WR FAIL! %c:%d r%u s0x%04X pre0x%04X\r\n", lastI2CErrPhase,
+              lastI2CErrStatus, lastI2CErrRetries, lastI2CErrSercomState,
+              lastI2CErrPreState);
       eepromBusRecovery();
       wlAsyncCtx.state = WL_ASYNC_IDLE;
     }


### PR DESCRIPTION
## Summary

Eliminate rare "WR FAIL! -> I2C RECOVERY" events on EEPROM operations. Root cause: `timerMicros()` occasionally returned stale COUNT values (~180 µs behind real time), causing spurious timeouts in `i2cActivate()` after only ~10 polling iterations.

## Root cause

`timerMicros()` used a one-shot `READREQ.RREQ` to synchronize the TC6 COUNT register from the 1 MHz timer clock domain to the 48 MHz APB bus domain. After writing RREQ, it polled `STATUS.SYNCBUSY` — but SYNCBUSY propagates asynchronously across clock domains. There is a window where SYNCBUSY is still clear from the *previous* sync, so `timerSync()` returns immediately and reads the **stale** COUNT value.

Diagnostic evidence (n10 d201): only 10 loop iterations in `i2cActivate()` (~10-20 µs real time), but `timerMicrosDelta()` reported 201 µs — proving the timer jumped forward ~180 µs.

## Fix

Enable `READREQ.RCONT` (Read Continuously) so hardware automatically synchronizes COUNT on every `CLK_TCx` edge (1 MHz). `timerMicros()` becomes a single atomic 32-bit register read — no READREQ, no SYNCBUSY poll, no interrupt protection needed.

Per Microchip docs:
- RREQ must be set once after RCONT to start continuous mode
- RCONT is cleared by any write to a TC core register (COUNT, CC)
- Added `timerTickRestoreRCONT()` helper called after all CC[1] writes

**References:**
- [ATSAMHA1 datasheet §31.8.2 — READREQ / RCONT register description](https://ww1.microchip.com/downloads/aemDocuments/documents/APID/ProductDocuments/DataSheets/ATSAMHA1EXXA-Data-Sheet-20005902B.pdf#page=539)
- [Microchip KB — RCONT sequence for SAM D (RCONT cleared by core register writes, CPU stall prevention)](https://support.microchip.com/s/article/What-is-the-sequence-to-be-followed-to-use-the-RCONT-bit-of-RTC-in-SAM-D-device)

**90+ hours of clean operation** confirms the fix.

## Defense-in-depth changes (retained)

- **`i2cAck()` STOP recovery**: After STOP, wait up to 100 µs for BUSSTATE→IDLE. If bus stays OWNER, perform SWRST + reinit instead of re-issuing STOP (which can hang the SERCOM per datasheet)
- **`writeBytes()` robustness**: NOACK retry loop (STOP + 500 µs, up to 10 retries), STOP on all failure paths, deferred state update
- **`eepromRead()`/`eepromInitBlock()`**: STOP on all failure paths
- **Diagnostics**: "WR FAIL!" printf with phase, status, retries, SERCOM STATUS, and pre-activate STATUS

## Files changed

- `src/driver_TIME.c` — RCONT setup in `timerSetup()`, simplified `timerMicros()`, `timerTickRestoreRCONT()` helper
- `src/driver_SERCOM.c` — SWRST recovery in `i2cAck()`, STOP-wait-for-IDLE
- `src/eeprom.c` — NOACK retry, STOP on all failure paths, diagnostics

## Test plan

- [x] Cross-compile builds cleanly for SAMD21
- [x] Diagnostics confirmed consistent `A:2 s0x00A0 pre0x0010 n10 d201` pattern (TIMEOUT with stale timer)
- [x] RCONT fix deployed — 90+ hours clean operation, zero I2C recovery events
- [x] Normal EEPROM read/write and wear-leveling functionality unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)